### PR TITLE
Add options config source

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ A complex configuration library that you should only use if you want to do thing
 
 This will load configuration from the following sources, with the later files over-riding any values set in the earlier ones (think of it as getting more specfic as you go down the list).
 
-1. argv params (--database.host db.example.com)
+1. options.config
 2. ./config/default.json
 3. ./config/[environment>].json
-4. ./config/runtime.json
-5. ./config/[your-hostname].json
-6. etcd:/conflab/service-name/_etcd/environment/config**
+5. ./config/runtime.json
+6. ./config/[your-hostname].json
+7. argv params (--database.host db.example.com)
+8. etcd:/conflab/service-name/_etcd/environment/config**
 
 So by specifying the majority of your configuration in ./config/default.json, you can then override the defaults in the environment or host specific sections using one or more of the other config locations.
 

--- a/index.js
+++ b/index.js
@@ -67,8 +67,8 @@ Config.prototype.loadConfig = function(next) {
 
     var self = this;
     async.series([
-        self.loadFromArgv.bind(this),
         self.loadFromFiles.bind(this),
+        self.loadFromArgv.bind(this),
         self.loadFromEtcd.bind(this),
         self.mergeConfig.bind(this)
     ], next);

--- a/index.js
+++ b/index.js
@@ -67,10 +67,11 @@ Config.prototype.loadConfig = function(next) {
 
     var self = this;
     async.series([
-        self.loadFromFiles.bind(this),
-        self.loadFromArgv.bind(this),
-        self.loadFromEtcd.bind(this),
-        self.mergeConfig.bind(this)
+        self.loadFromOptions.bind(self),
+        self.loadFromFiles.bind(self),
+        self.loadFromArgv.bind(self),
+        self.loadFromEtcd.bind(self),
+        self.mergeConfig.bind(self)
     ], next);
 }
 

--- a/index.js
+++ b/index.js
@@ -29,11 +29,14 @@ Config.prototype.load = function(options, next) {
     if(!next) {
         next = options;
         options = {};
+    } else {
+        options = options || {};
     }
 
     var self = this;
     if(self.loaded) return next(null, self.config);
 
+    self.options = options;
     self.loaded = false;
     self.heartbeatInterval = 10000;
 
@@ -174,6 +177,15 @@ Config.prototype.loadFromEtcd = function(next) {
         parseConfig(config.node, next);
     });
 
+}
+
+Config.prototype.loadFromOptions = function(next) {
+    var self = this;
+    if (_.isEmpty(self.options.config)) return next();
+    var data = _.cloneDeep(self.options.config);
+    self.fileContent.opts = data;
+    self.fileConfig = defaultsDeep(_.cloneDeep(data), self.fileConfig);
+    next();
 }
 
 Config.prototype.loadFromArgv = function(next) {

--- a/index.js
+++ b/index.js
@@ -66,14 +66,12 @@ Config.prototype.load = function(options, next) {
 Config.prototype.loadConfig = function(next) {
 
     var self = this;
-    self.loadFromArgv(function() {
-        self.loadFromFiles(function() {
-            self.loadFromEtcd(function() {
-                self.mergeConfig(next);
-            });
-        });
-    });
-
+    async.series([
+        self.loadFromArgv.bind(this),
+        self.loadFromFiles.bind(this),
+        self.loadFromEtcd.bind(this),
+        self.mergeConfig.bind(this)
+    ], next);
 }
 
 /**

--- a/tests/config.test.js
+++ b/tests/config.test.js
@@ -9,10 +9,16 @@ var path = require('path');
 describe('Config file module', function() {
 
     var config, Conflab = require('..'), conflab = new Conflab();
+    var options = {
+        config: {
+            serviceKey: 'options',
+            serviceKey4: 'options'
+        }
+    };
 
     before(function(done) {
         process.env.CONFLAB_CONFIG = path.join(__dirname,'file');
-        conflab.load(function(err, conflabConfig) {
+        conflab.load(options, function(err, conflabConfig) {
             config = conflabConfig;
             done();
         })
@@ -22,6 +28,7 @@ describe('Config file module', function() {
         expect(config.serviceKey1).to.be('default');
         expect(config.serviceKey2).to.be('environment');
         expect(config.serviceKey3).to.be('runtime');
+        expect(config.serviceKey4).to.be('options');
     });
 
     it('should over-ride based on order', function() {


### PR DESCRIPTION
Allows additional config source to be passed as config field in options object. Allows "hardcoded" or determined at runtime values to be used as config. This enables users to treat all their config in a uniform way.

"Fix" for #2 was also sneaked in to avoid detection. :wink:   