### PR TITLE
command-line arguments should override etcd

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,8 +77,8 @@ Config.prototype.loadConfig = function(next) {
     async.series([
         self.loadFromOptions.bind(self),
         self.loadFromFiles.bind(self),
-        self.loadFromArgv.bind(self),
         self.loadFromEtcd.bind(self),
+        self.loadFromArgv.bind(self),
         self.mergeConfig.bind(self)
     ], next);
 }


### PR DESCRIPTION
Should they not?